### PR TITLE
Add header in lists and auto close sidemenu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matte-ui",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Matte is a UI component library on top of MUI and other react libraries.",
   "author": "Squaredev",
   "license": "Apache-2.0",

--- a/src/components/display/list/list.component.tsx
+++ b/src/components/display/list/list.component.tsx
@@ -23,6 +23,7 @@ export interface ListItemProps {
   icon?: React.ReactElement;
   primaryEnd?: string | number;
   secondaryEnd?: string | number;
+  header?: boolean;
 }
 
 export interface ListProps {
@@ -56,6 +57,7 @@ export interface ListProps {
    * primaryEnd | string | Primary text to show at the right side of the item. | -
    * secondaryEnd | string | Secondary text to show at the right side of the item. | -
    * handleClick | function | A function that will be executed on item's `onClick` method, e.g. `(e) => console.log(e)`. By default, `e`, the React's synthetic event, is passed to that function. When additional parameters are passed by another API implementation, e.g. `Table`, it is explicitly documented. | -
+   * header | boolean | When true the list item becomes a header | false
    *
    */
   items: ListItemProps[];
@@ -102,6 +104,14 @@ const useStyles = makeStyles(() =>
       minWidth: 60,
       marginRight: '10%',
     },
+    header: {
+      padding: '24px 24px 8px 8px !important',
+      '& .MuiListItemText-primary': {
+        textTransform: 'uppercase',
+        fontSize: 12,
+        fontWeight: 600,
+      },
+    },
   })
 );
 
@@ -140,6 +150,7 @@ const ListItemBase = ({
   secondaryEnd,
   className,
   disableGutters,
+  header = false,
 }: ListItemBaseProps) => {
   const classes = useStyles({ disableGutters });
   return (
@@ -162,6 +173,7 @@ const ListItemBase = ({
         className={classes.listItemText}
         primary={primary}
         secondary={secondary}
+        inset={header}
       />
       {primaryEnd && (
         <ListItemText
@@ -227,7 +239,9 @@ export const List: React.FC<ListProps> = ({
   const [activeLi, setActiveLi] = React.useState(-1);
 
   const handleClick = (e: any, item: any, i: number) => {
-    setActiveLi(i);
+    if (!item.header) {
+      setActiveLi(i);
+    }
     const params =
       handleClickParams && handleClickParams.length
         ? [e, ...handleClickParams]
@@ -244,7 +258,12 @@ export const List: React.FC<ListProps> = ({
           return (
             <Fragment key={i}>
               {i > 0 && divider && <Divider component="li" light />}
-              <li className={clsx({ active: activeLi === i })}>
+              <li
+                className={clsx({
+                  active: activeLi === i,
+                  [classes.header]: item.header,
+                })}
+              >
                 <ListItemLink
                   avatar={item.avatar}
                   circularProgressBar={item.circularProgressBar}
@@ -274,7 +293,10 @@ export const List: React.FC<ListProps> = ({
               primaryEnd={item.primaryEnd}
               secondaryEnd={item.secondaryEnd}
               handleClick={(e: any) => handleClick(e, item, i)}
-              className={clsx({ active: activeLi === i })}
+              className={clsx({
+                active: activeLi === i,
+                [classes.header]: item.header,
+              })}
               disableGutters={disableGutters}
             />
           </Fragment>

--- a/src/components/layouts/layout.component.tsx
+++ b/src/components/layouts/layout.component.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import clsx from 'clsx';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Drawer from '@material-ui/core/Drawer';
@@ -9,6 +9,7 @@ import { IconButton } from '../inputs/button/button.component';
 import { Menu as MenuIcon, ChevronLeft, LogOut, User } from 'react-feather';
 import { List, ListItemProps } from '../display/list/list.component';
 import { Menu } from '../navigation/menu/menu.component';
+import { useMediaQuery } from '@material-ui/core';
 
 const drawerWidth = 240;
 
@@ -56,28 +57,24 @@ const useStyles = makeStyles((theme: Theme) =>
       display: 'none',
     },
     drawer: {
-      width: drawerWidth,
       flexShrink: 0,
-      whiteSpace: 'nowrap',
     },
     drawerOpen: {
+      transform: 'translateX(0)',
       width: drawerWidth,
       zIndex: theme.zIndex.drawer + 1,
-      transition: theme.transitions.create('width', {
+      transition: theme.transitions.create('transform', {
         easing: theme.transitions.easing.sharp,
         duration: theme.transitions.duration.enteringScreen,
       }),
     },
     drawerClose: {
-      transition: theme.transitions.create('width', {
+      width: 0,
+      transform: `translateX(-${drawerWidth}px)`,
+      transition: theme.transitions.create('transform', {
         easing: theme.transitions.easing.sharp,
         duration: theme.transitions.duration.leavingScreen,
       }),
-      overflowX: 'hidden',
-      width: theme.spacing(7) + 1,
-      [theme.breakpoints.up('sm')]: {
-        width: theme.spacing(8) + 1,
-      },
     },
     toolbar: {
       display: 'flex',
@@ -155,6 +152,11 @@ export const Layout: FC<LayoutProps> = ({
   const classes = useStyles();
 
   const userAvatar = <IconButton icon={<User />} />;
+  const isWideScreen = useMediaQuery('(min-width:1280px)');
+
+  useEffect(() => {
+    setOpen(isWideScreen);
+  }, [isWideScreen]);
 
   const userMenuItems = [
     {

--- a/src/components/layouts/layout.stories.tsx
+++ b/src/components/layouts/layout.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Layout } from './layout.component';
 import { Typography } from '@material-ui/core';
-import { Users, Home, Send, PieChart } from 'react-feather';
+import { Home, Columns, Shield, Settings, Book } from 'react-feather';
 
 export default {
   title: 'Components/Structures/Layout',
@@ -15,60 +15,70 @@ export default {
 const menuItems = [
   {
     icon: <Home />,
-    primary: 'Home',
+    primary: 'Overview',
     to: 'infinity and beyond!',
   },
   {
-    icon: <Send />,
-    primary: 'Invitations',
+    primary: 'Products',
+    header: true,
+  },
+  {
+    icon: <Columns />,
+    primary: 'Awesome product 1',
     to: 'infinity and beyond!',
   },
   {
-    icon: <Users />,
-    primary: 'Customers',
+    icon: <Shield />,
+    primary: 'Awesome product 2',
     to: 'infinity and beyond!',
   },
   {
-    icon: <PieChart />,
-    primary: 'Reports',
+    primary: 'Account',
+    header: true,
+  },
+  {
+    icon: <Settings />,
+    primary: 'Settings',
+    to: 'infinity and beyond!',
+  },
+  {
+    icon: <Book />,
+    primary: 'API docs',
     to: 'infinity and beyond!',
   },
 ];
 
 export const BasicLayout = () => (
-         <div>
-           <Layout menuItems={menuItems} logo="images/matte-logo-storybook.png">
-             <Typography paragraph>
-               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-               eiusmod tempor incididunt ut labore et dolore magna aliqua.
-               Rhoncus dolor purus non enim praesent elementum facilisis leo
-               vel. Risus at ultrices mi tempus imperdiet. Semper risus in
-               hendrerit gravida rutrum quisque non tellus. Convallis convallis
-               tellus id interdum velit laoreet id donec ultrices. Odio morbi
-               quis commodo odio aenean sed adipiscing. Amet nisl suscipit
-               adipiscing bibendum est ultricies integer quis. Cursus euismod
-               quis viverra nibh cras. Metus vulputate eu scelerisque felis
-               imperdiet proin fermentum leo. Mauris commodo quis imperdiet
-               massa tincidunt. Cras tincidunt lobortis feugiat vivamus at
-               augue. At augue eget arcu dictum varius duis at consectetur
-               lorem. Velit sed ullamcorper morbi tincidunt. Lorem donec massa
-               sapien faucibus et molestie ac.
-             </Typography>
-             <Typography paragraph>
-               Consequat mauris nunc congue nisi vitae suscipit. Fringilla est
-               ullamcorper eget nulla facilisi etiam dignissim diam. Pulvinar
-               elementum integer enim neque volutpat ac tincidunt. Ornare
-               suspendisse sed nisi lacus sed viverra tellus. Purus sit amet
-               volutpat consequat mauris. Elementum eu facilisis sed odio morbi.
-               Euismod lacinia at quis risus sed vulputate odio. Morbi tincidunt
-               ornare massa eget egestas purus viverra accumsan in. In hendrerit
-               gravida rutrum quisque non tellus orci ac. Pellentesque nec nam
-               aliquam sem et tortor. Habitant morbi tristique senectus et.
-               Adipiscing elit duis tristique sollicitudin nibh sit. Ornare
-               aenean euismod elementum nisi quis eleifend. Commodo viverra
-               maecenas accumsan lacus vel facilisis. Nulla posuere sollicitudin
-               aliquam ultrices sagittis orci a.
-             </Typography>
-           </Layout>
-         </div>
-       )
+  <div>
+    <Layout menuItems={menuItems} logo="images/matte-logo-storybook.png">
+      <Typography paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Rhoncus dolor purus
+        non enim praesent elementum facilisis leo vel. Risus at ultrices mi
+        tempus imperdiet. Semper risus in hendrerit gravida rutrum quisque non
+        tellus. Convallis convallis tellus id interdum velit laoreet id donec
+        ultrices. Odio morbi quis commodo odio aenean sed adipiscing. Amet nisl
+        suscipit adipiscing bibendum est ultricies integer quis. Cursus euismod
+        quis viverra nibh cras. Metus vulputate eu scelerisque felis imperdiet
+        proin fermentum leo. Mauris commodo quis imperdiet massa tincidunt. Cras
+        tincidunt lobortis feugiat vivamus at augue. At augue eget arcu dictum
+        varius duis at consectetur lorem. Velit sed ullamcorper morbi tincidunt.
+        Lorem donec massa sapien faucibus et molestie ac.
+      </Typography>
+      <Typography paragraph>
+        Consequat mauris nunc congue nisi vitae suscipit. Fringilla est
+        ullamcorper eget nulla facilisi etiam dignissim diam. Pulvinar elementum
+        integer enim neque volutpat ac tincidunt. Ornare suspendisse sed nisi
+        lacus sed viverra tellus. Purus sit amet volutpat consequat mauris.
+        Elementum eu facilisis sed odio morbi. Euismod lacinia at quis risus sed
+        vulputate odio. Morbi tincidunt ornare massa eget egestas purus viverra
+        accumsan in. In hendrerit gravida rutrum quisque non tellus orci ac.
+        Pellentesque nec nam aliquam sem et tortor. Habitant morbi tristique
+        senectus et. Adipiscing elit duis tristique sollicitudin nibh sit.
+        Ornare aenean euismod elementum nisi quis eleifend. Commodo viverra
+        maecenas accumsan lacus vel facilisis. Nulla posuere sollicitudin
+        aliquam ultrices sagittis orci a.
+      </Typography>
+    </Layout>
+  </div>
+);


### PR DESCRIPTION
Lists now may have non-clickable headers to define different sections
(submenus) when used for menu lists (e.g. a side menu). Also now
sidemenu auto closes / opens according to window size.

RES WYS-695