### PR TITLE
fix: Table item with link

### DIFF
--- a/src/components/display/table/table.component.tsx
+++ b/src/components/display/table/table.component.tsx
@@ -124,7 +124,6 @@ const getCellContent = (row: any, col: any, selected: number[]) => {
             color: 'primary.dark',
           },
         }}
-        component={col.routerLink}
         to={row.to as string}
       >
         {row[col.field]}


### PR DESCRIPTION
When the default Link component from the react-router-dom was provided the link was not working. 

The component property is removed, the consumer can directly provide a custom Link in the col.routerLink property if necessary.