### PR TITLE
Adds React.forwardRef to fix ref error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matte-ui",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "Matte is a UI component library on top of MUI and other react libraries.",
   "author": "Squaredev",
   "license": "Apache-2.0",

--- a/src/components/inputs/select/select.component.tsx
+++ b/src/components/inputs/select/select.component.tsx
@@ -65,83 +65,93 @@ export interface SelectProps {
    * Whether multiple elements can be selected.
    */
   multiple?: boolean;
+  /**
+   * Pass a ref to the input element.
+   */
+  inputRef?: React.Ref<any>;
 }
 
-export const Select: FC<SelectProps> = ({
-  id,
-  placeholder,
-  disabled = false,
-  multiple = false,
-  value = '',
-  error = false,
-  helperText,
-  label,
-  required = false,
-  items = [],
-  onChange,
-  renderValue,
-}) => {
-  return (
-    <FormControl
-      variant="outlined"
-      className={styles.formControl}
-      error={error}
-    >
-      {label && (
-        <InputLabel
-          variant="standard"
-          className={styles.label}
-          htmlFor={id}
-          disableAnimation
-          required={required}
-          sx={{
-            color: 'common.black',
-            '&.Mui-focused': {
-              color: 'common.black',
-            },
-          }}
-        >
-          {label}
-        </InputLabel>
-      )}
-      <MuiSelect
-        id={id}
-        labelId="select"
-        input={
-          <InputBase
-            id={`${id}-input`}
-            fullWidth
-            classes={{ input: styles.input }}
-            sx={{
-              border: ({ palette }) => `1px solid ${palette.grey[200]}`,
-            }}
-          />
-        }
-        IconComponent={ChevronDown}
-        displayEmpty={!!placeholder}
-        defaultValue={value}
-        disabled={disabled}
-        onChange={onChange}
-        multiple={multiple}
-        value={value}
-        renderValue={renderValue}
+export const Select: FC<SelectProps> = React.forwardRef(
+  (
+    {
+      id,
+      placeholder,
+      disabled = false,
+      multiple = false,
+      value = '',
+      error = false,
+      helperText,
+      label,
+      required = false,
+      items = [],
+      onChange,
+      renderValue,
+    },
+    ref
+  ) => {
+    return (
+      <FormControl
+        variant="outlined"
+        className={styles.formControl}
+        error={error}
       >
-        {placeholder && (
-          <MenuItem className={styles.menuItem} value="">
-            {placeholder}
-          </MenuItem>
+        {label && (
+          <InputLabel
+            variant="standard"
+            className={styles.label}
+            htmlFor={id}
+            disableAnimation
+            required={required}
+            sx={{
+              color: 'common.black',
+              '&.Mui-focused': {
+                color: 'common.black',
+              },
+            }}
+          >
+            {label}
+          </InputLabel>
         )}
-        {items.map((item, i) => (
-          <MenuItem value={item.value} className={styles.menuItem} key={i}>
-            {item.text}
-          </MenuItem>
-        ))}
-      </MuiSelect>
-      {helperText && (
-        <FormHelperText error={error} id={`${id}-helper-text`}>
-          {helperText}
-        </FormHelperText>
-      )}
-    </FormControl>
-  );
-};
+        <MuiSelect
+          id={id}
+          labelId="select"
+          inputRef={ref}
+          input={
+            <InputBase
+              id={`${id}-input`}
+              fullWidth
+              classes={{ input: styles.input }}
+              sx={{
+                border: ({ palette }) => `1px solid ${palette.grey[200]}`,
+              }}
+            />
+          }
+          IconComponent={ChevronDown}
+          displayEmpty={!!placeholder}
+          defaultValue={value}
+          disabled={disabled}
+          onChange={onChange}
+          multiple={multiple}
+          value={value}
+          renderValue={renderValue}
+        >
+          {placeholder && (
+            <MenuItem className={styles.menuItem} value="">
+              {placeholder}
+            </MenuItem>
+          )}
+          {items.map((item, i) => (
+            <MenuItem value={item.value} className={styles.menuItem} key={i}>
+              {item.text}
+            </MenuItem>
+          ))}
+        </MuiSelect>
+        {helperText && (
+          <FormHelperText error={error} id={`${id}-helper-text`}>
+            {helperText}
+          </FormHelperText>
+        )}
+      </FormControl>
+    );
+  }
+);

--- a/src/components/inputs/textField/textField.component.tsx
+++ b/src/components/inputs/textField/textField.component.tsx
@@ -72,83 +72,89 @@ export interface TextFieldProps {
 /**
  * Text fields are used within forms to submit or edit information.
  */
-export const TextField: FC<TextFieldProps> = ({
-  id,
-  placeholder,
-  disabled = false,
-  icon,
-  value,
-  defaultValue,
-  error = false,
-  helperText,
-  label,
-  required = false,
-  onChange: handleChange,
-  inputRef,
-  name,
-  type,
-  pattern,
-}) => {
-  return (
-    <FormControl className={styles.formControl} fullWidth variant="outlined">
-      {label && (
-        <MuiInputLabel
-          variant="standard"
-          className={styles.label}
-          htmlFor={id}
-          disableAnimation
-          shrink
-          required={required}
-          sx={{
-            color: 'common.black',
-            '&.Mui-focused': {
+export const TextField: FC<TextFieldProps> = React.forwardRef(
+  (
+    {
+      id,
+      placeholder,
+      disabled = false,
+      icon,
+      value,
+      defaultValue,
+      error = false,
+      helperText,
+      label,
+      required = false,
+      onChange: handleChange,
+      name,
+      type,
+      pattern,
+    },
+    ref
+  ) => {
+    return (
+      <FormControl className={styles.formControl} fullWidth variant="outlined">
+        {label && (
+          <MuiInputLabel
+            variant="standard"
+            className={styles.label}
+            htmlFor={id}
+            disableAnimation
+            shrink
+            required={required}
+            sx={{
               color: 'common.black',
+              '&.Mui-focused': {
+                color: 'common.black',
+              },
+            }}
+          >
+            {label}
+          </MuiInputLabel>
+        )}
+        <MuiOutlinedInput
+          id={id}
+          placeholder={placeholder}
+          className={styles.textField}
+          value={value}
+          defaultValue={defaultValue}
+          disabled={disabled}
+          error={error}
+          fullWidth
+          required={required}
+          onChange={handleChange}
+          inputRef={ref}
+          name={name}
+          type={type}
+          inputProps={{
+            pattern,
+          }}
+          startAdornment={
+            icon ? (
+              <InputAdornment position="start">{icon}</InputAdornment>
+            ) : null
+          }
+          sx={{
+            '& .MuiOutlinedInput-notchedOutline': {
+              borderColor: ({ palette }) => palette.grey[200],
+            },
+            '&:hover .MuiOutlinedInput-notchedOutline': {
+              borderColor: ({ palette }) => palette.grey[200],
+            },
+            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+              borderColor: 'primary.main',
+            },
+            '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+              borderColor: 'error.main',
             },
           }}
-        >
-          {label}
-        </MuiInputLabel>
-      )}
-      <MuiOutlinedInput
-        id={id}
-        placeholder={placeholder}
-        className={styles.textField}
-        value={value}
-        defaultValue={defaultValue}
-        disabled={disabled}
-        error={error}
-        fullWidth
-        required={required}
-        onChange={handleChange}
-        inputRef={inputRef}
-        name={name}
-        type={type}
-        inputProps={{
-          pattern,
-        }}
-        startAdornment={
-          icon ? <InputAdornment position="start">{icon}</InputAdornment> : null
-        }
-        sx={{
-          '& .MuiOutlinedInput-notchedOutline': {
-            borderColor: ({ palette }) => palette.grey[200],
-          },
-          '&:hover .MuiOutlinedInput-notchedOutline': {
-            borderColor: ({ palette }) => palette.grey[200],
-          },
-          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-            borderColor: 'primary.main',
-          },
-          '&.Mui-error .MuiOutlinedInput-notchedOutline': {
-            borderColor: 'error.main',
-          },
-        }}
-      />
-      {helperText && (
-        <FormHelperText error={error} id={`${id}-helper-text`}>
-          {helperText}
-        </FormHelperText>
-      )}
-    </FormControl>
-  );
-};
+        />
+        {helperText && (
+          <FormHelperText error={error} id={`${id}-helper-text`}>
+            {helperText}
+          </FormHelperText>
+        )}
+      </FormControl>
+    );
+  }
+);


### PR DESCRIPTION
<img width="1185" alt="Screenshot 2022-03-04 at 5 02 30 PM" src="https://user-images.githubusercontent.com/68306689/156787124-d0bb745b-3daf-4112-af60-fcc9ca0ae00d.png">

Used React.forwardReact to fix the bug that causes the above error when using the textfield : "Function components cannot be given refs. Attempts to access this ref will fail." which is why the data from the form couldn't be fetched. 