### PR TITLE
Allow some ListItemProps to use ReactNode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matte-ui",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "matte-ui",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@mui/base": "5.0.0-alpha.67",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matte-ui",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "matte-ui",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@mui/base": "5.0.0-alpha.67",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matte-ui",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Matte is a UI component library on top of MUI and other react libraries.",
   "author": "Squaredev",
   "license": "Apache-2.0",

--- a/src/components/display/list/list.component.tsx
+++ b/src/components/display/list/list.component.tsx
@@ -11,18 +11,18 @@ import styles from './list.module.scss';
 // TODO: how to solve the component problem?
 
 export interface ListItemProps {
-  avatar?: React.ReactElement;
-  circularProgressBar?: React.ReactElement;
+  avatar?: React.ReactNode;
+  circularProgressBar?: React.ReactNode;
   classNames?: string[];
-  primary: string;
-  secondary?: string;
+  primary: React.ReactNode;
+  secondary?: React.ReactNode;
   to?: string;
   handleClick?: React.MouseEventHandler;
-  icon?: React.ReactElement;
-  primaryEnd?: string | number;
-  secondaryEnd?: string | number;
+  icon?: React.ReactNode;
+  primaryEnd?: React.ReactNode;
+  secondaryEnd?: React.ReactNode;
   header?: boolean;
-  routerLink?: any; //TODO: Fix type
+  routerLink?: any;
 }
 
 export interface ListProps {


### PR DESCRIPTION
This is a non-breaking change because `React.ReactNode` includes `number | string | React.ReactElement`