### PR TITLE
Fix: Menu - popup menu behavior on item selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matte-ui",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Matte is a UI component library on top of MUI and other react libraries.",
   "author": "Squaredev",
   "license": "Apache-2.0",

--- a/src/components/navigation/menu/menu.component.tsx
+++ b/src/components/navigation/menu/menu.component.tsx
@@ -109,6 +109,7 @@ export const Menu: FC<MenuProps> = ({
         : [e];
     if (item.handleClick) {
       item.handleClick(...params);
+      popupState.close();
     }
   };
 


### PR DESCRIPTION
This is a fix related with the popup state of the dropdown menu coming from Menu.

Before: A user would click an option in the menu, but the menu would stay open. For the menu to close, the user had to click in an outside area.

After: A user can now click any option in the menu, making the menu close as expected.

Details: Given that matte-ui's solution is already using material-ui-popup-state, I felt inclined to fix this by following their example code as shown [here](https://jcoreio.github.io/material-ui-popup-state/). The idea is to call `popupState.close` when an item is clicked. Given that there's already a click handler, I included the call inside of it. 

However, I'm unable to verify its backwards compatibility, that is if any project(s) assume that the menu stays open is an intentional behavior. My tests were only made in the included storybook implementation.