### PR TITLE
Feat: Adds labelLeft props to TextField

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "matte-ui",
-<<<<<<< HEAD
-  "version": "0.12.7",
-=======
-  "version": "0.12.8",
->>>>>>> master
+  "version": "0.12.9",
   "description": "Matte is a UI component library on top of MUI and other react libraries.",
   "author": "Squaredev",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matte-ui",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "Matte is a UI component library on top of MUI and other react libraries.",
   "author": "Squaredev",
   "license": "Apache-2.0",

--- a/src/components/inputs/textField/textField.component.tsx
+++ b/src/components/inputs/textField/textField.component.tsx
@@ -7,6 +7,7 @@ import {
   FormControl,
   FormHelperText,
   InputAdornment,
+  Box,
 } from '@mui/material';
 
 export interface TextFieldProps {
@@ -86,6 +87,10 @@ export interface TextFieldProps {
    * Maximum number of rows to display when multiline option is set to true.
    */
   maxRows?: number | string;
+  /**
+   * When set to true, label is shown on the left.
+   */
+  labelLeft?: boolean;
 }
 
 /**
@@ -112,74 +117,150 @@ export const TextField: FC<TextFieldProps> = React.forwardRef(
       rows,
       minRows,
       maxRows,
+      labelLeft,
     },
     ref
   ) => {
     return (
       <FormControl className={styles.formControl} fullWidth variant="outlined">
-        {label && (
-          <MuiInputLabel
-            variant="standard"
-            className={styles.label}
-            htmlFor={id}
-            disableAnimation
-            shrink
-            required={required}
+        {label && labelLeft ? (
+          <Box
             sx={{
-              color: 'common.black',
-              '&.Mui-focused': {
-                color: 'common.black',
-              },
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
             }}
           >
-            {label}
-          </MuiInputLabel>
-        )}
-        <MuiOutlinedInput
-          id={id}
-          placeholder={placeholder}
-          className={styles.textField}
-          value={value}
-          defaultValue={defaultValue}
-          disabled={disabled}
-          error={error}
-          fullWidth
-          required={required}
-          onChange={handleChange}
-          inputRef={ref}
-          name={name}
-          type={type}
-          multiline={multiline}
-          rows={rows}
-          minRows={minRows}
-          maxRows={maxRows}
-          inputProps={{
-            pattern,
-          }}
-          startAdornment={
-            icon ? (
-              <InputAdornment position="start">{icon}</InputAdornment>
-            ) : null
-          }
-          sx={{
-            '& .MuiOutlinedInput-notchedOutline': {
-              borderColor: ({ palette }) => palette.grey[200],
-            },
-            '&:hover .MuiOutlinedInput-notchedOutline': {
-              borderColor: ({ palette }) => palette.grey[200],
-            },
-            '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-              borderColor: 'primary.main',
-            },
-            '&.Mui-error .MuiOutlinedInput-notchedOutline': {
-              borderColor: 'error.main',
-            },
-          }}
-        />
-        {helperText && (
-          <FormHelperText error={error} id={`${id}-helper-text`}>
-            {helperText}
-          </FormHelperText>
+            <MuiInputLabel
+              variant="standard"
+              className={`${styles.label} ${styles.labelLeft}`}
+              htmlFor={id}
+              disableAnimation
+              required={required}
+              sx={{
+                color: 'common.black',
+                '&.Mui-focused': {
+                  color: 'common.black',
+                },
+              }}
+            >
+              {label}
+            </MuiInputLabel>
+            <MuiOutlinedInput
+              id={id}
+              placeholder={placeholder}
+              className={styles.textField}
+              value={value}
+              defaultValue={defaultValue}
+              disabled={disabled}
+              error={error}
+              required={required}
+              onChange={handleChange}
+              inputRef={ref}
+              name={name}
+              type={type}
+              multiline={multiline}
+              rows={rows}
+              minRows={minRows}
+              maxRows={maxRows}
+              inputProps={{
+                pattern,
+              }}
+              startAdornment={
+                icon ? (
+                  <InputAdornment position="start">{icon}</InputAdornment>
+                ) : null
+              }
+              sx={{
+                '& .MuiOutlinedInput-notchedOutline': {
+                  borderColor: ({ palette }) => palette.grey[200],
+                },
+                '&:hover .MuiOutlinedInput-notchedOutline': {
+                  borderColor: ({ palette }) => palette.grey[200],
+                },
+                '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'primary.main',
+                },
+                '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'error.main',
+                },
+                flex: '1',
+                marginLeft: '16px',
+              }}
+            />
+            {helperText && (
+              <FormHelperText error={error} id={`${id}-helper-text`}>
+                {helperText}
+              </FormHelperText>
+            )}
+          </Box>
+        ) : (
+          <>
+            {label && (
+              <MuiInputLabel
+                variant="standard"
+                className={styles.label}
+                htmlFor={id}
+                disableAnimation
+                shrink
+                required={required}
+                sx={{
+                  color: 'common.black',
+                  '&.Mui-focused': {
+                    color: 'common.black',
+                  },
+                }}
+              >
+                {label}
+              </MuiInputLabel>
+            )}
+            <MuiOutlinedInput
+              id={id}
+              placeholder={placeholder}
+              className={styles.textField}
+              value={value}
+              defaultValue={defaultValue}
+              disabled={disabled}
+              error={error}
+              fullWidth
+              required={required}
+              onChange={handleChange}
+              inputRef={ref}
+              name={name}
+              type={type}
+              multiline={multiline}
+              rows={rows}
+              minRows={minRows}
+              maxRows={maxRows}
+              inputProps={{
+                pattern,
+              }}
+              startAdornment={
+                icon ? (
+                  <InputAdornment position="start">{icon}</InputAdornment>
+                ) : null
+              }
+              sx={{
+                '& .MuiOutlinedInput-notchedOutline': {
+                  borderColor: ({ palette }) => palette.grey[200],
+                },
+                '&:hover .MuiOutlinedInput-notchedOutline': {
+                  borderColor: ({ palette }) => palette.grey[200],
+                },
+                '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'primary.main',
+                },
+                '&.Mui-error .MuiOutlinedInput-notchedOutline': {
+                  borderColor: 'error.main',
+                },
+              }}
+            />
+            {helperText && (
+              <FormHelperText error={error} id={`${id}-helper-text`}>
+                {helperText}
+              </FormHelperText>
+            )}
+          </>
         )}
       </FormControl>
     );

--- a/src/components/inputs/textField/textField.component.tsx
+++ b/src/components/inputs/textField/textField.component.tsx
@@ -130,21 +130,13 @@ export const TextField: FC<TextFieldProps> = React.forwardRef(
     return (
       <FormControl className={styles.formControl} fullWidth variant="outlined">
         {label && labelLeft ? (
-          <div className={styles.textFieldWrapper}
-     
-          >
+          <div className={styles.textFieldWrapper}>
             <MuiInputLabel
               variant="standard"
               className={`${styles.label} ${styles.labelLeft}`}
               htmlFor={id}
               disableAnimation
               required={required}
-              sx={{
-                color: 'common.black',
-                '&.Mui-focused': {
-                  color: 'common.black',
-                },
-              }}
             >
               {label}
             </MuiInputLabel>
@@ -207,12 +199,6 @@ export const TextField: FC<TextFieldProps> = React.forwardRef(
                 disableAnimation
                 shrink
                 required={required}
-                sx={{
-                  color: 'common.black',
-                  '&.Mui-focused': {
-                    color: 'common.black',
-                  },
-                }}
               >
                 {label}
               </MuiInputLabel>

--- a/src/components/inputs/textField/textField.component.tsx
+++ b/src/components/inputs/textField/textField.component.tsx
@@ -8,7 +8,6 @@ import {
   FormControl,
   FormHelperText,
   InputAdornment,
-  Box,
 } from '@mui/material';
 import { TextFieldProps as MuiTextFieldProps } from '@mui/material';
 
@@ -131,12 +130,8 @@ export const TextField: FC<TextFieldProps> = React.forwardRef(
     return (
       <FormControl className={styles.formControl} fullWidth variant="outlined">
         {label && labelLeft ? (
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'flex-end',
-            }}
+          <div className={styles.textFieldWrapper}
+     
           >
             <MuiInputLabel
               variant="standard"
@@ -201,7 +196,7 @@ export const TextField: FC<TextFieldProps> = React.forwardRef(
                 {helperText}
               </FormHelperText>
             )}
-          </Box>
+          </div>
         ) : (
           <>
             {label && (

--- a/src/components/inputs/textField/textField.module.scss
+++ b/src/components/inputs/textField/textField.module.scss
@@ -28,10 +28,26 @@
 }
 // see: https://github.com/css-modules/css-modules/issues/295
 
+:global {
+  :local(.label) {
+    &.MuiInputLabel-root {
+      color: black;
+    }
+  }
+}
+
+:global {
+  :local(.label) {
+    &.Mui-focused {
+      color: black;
+    }
+  }
+}
+
 .textFieldWrapper {
   display: flex;
   align-items: center;
-  justify-content: flex-end
+  justify-content: flex-end;
 }
 
 .label {
@@ -40,9 +56,6 @@
   margin-bottom: 8px;
   transform: initial;
   position: relative;
-  // '&.Mui-focused': {
-  //   color: palette.common.black,
-  // },
 }
 
 .labelLeft {

--- a/src/components/inputs/textField/textField.module.scss
+++ b/src/components/inputs/textField/textField.module.scss
@@ -38,6 +38,13 @@
   //   color: palette.common.black,
   // },
 }
+
+.labelLeft {
+  margin-bottom: 0px;
+  text-align: right;
+  width: 30%;
+}
+
 .formControl {
   margin-bottom: 16px;
 }

--- a/src/components/inputs/textField/textField.module.scss
+++ b/src/components/inputs/textField/textField.module.scss
@@ -28,6 +28,12 @@
 }
 // see: https://github.com/css-modules/css-modules/issues/295
 
+.textFieldWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end
+}
+
 .label {
   font-size: 0.875rem;
   line-height: 1.4rem;

--- a/src/components/inputs/textField/textField.stories.tsx
+++ b/src/components/inputs/textField/textField.stories.tsx
@@ -31,6 +31,18 @@ export const TextFields: ComponentStory<typeof TextField> = () => {
         helperText="You got some error, check again"
       />
       <TextField
+        id="input-with-label-left"
+        placeholder="Input with left-align label"
+        label="Label left"
+        labelLeft
+      />
+      <TextField
+        id="input-with-label-left-2"
+        placeholder="Input with left-align label"
+        label="Label with a different length"
+        labelLeft
+      />
+      <TextField
         id="input-with-label"
         placeholder="Input with label"
         label="Some label"


### PR DESCRIPTION
New props to be able to position the labels on the left of the textField instead of on top.
![Screenshot 2022-06-24 at 5 00 47 PM](https://user-images.githubusercontent.com/68306689/175552878-50c8a935-5f97-4c95-8bfb-f65e5101e99d.png)

