### PR TITLE
Allow inputProps for Textfield component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "matte-ui",
-  "version": "0.12.4",
+  "version": "0.12.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "matte-ui",
-      "version": "0.12.4",
+      "version": "0.12.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@mui/base": "^5.0.0-alpha.67",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matte-ui",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "description": "Matte is a UI component library on top of MUI and other react libraries.",
   "author": "Squaredev",
   "license": "Apache-2.0",

--- a/src/components/inputs/textField/textField.component.tsx
+++ b/src/components/inputs/textField/textField.component.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React, { FC } from 'react';
 import styles from './textField.module.scss';
 
@@ -8,6 +9,7 @@ import {
   FormHelperText,
   InputAdornment,
 } from '@mui/material';
+import { TextFieldProps as MuiTextFieldProps } from '@mui/material';
 
 export interface TextFieldProps {
   /**
@@ -86,6 +88,10 @@ export interface TextFieldProps {
    * Maximum number of rows to display when multiline option is set to true.
    */
   maxRows?: number | string;
+  /**
+   * Input attribute as props
+   */
+  inputProps?: MuiTextFieldProps['inputProps'];
 }
 
 /**
@@ -112,6 +118,7 @@ export const TextField: FC<TextFieldProps> = React.forwardRef(
       rows,
       minRows,
       maxRows,
+      inputProps = {},
     },
     ref
   ) => {
@@ -155,6 +162,7 @@ export const TextField: FC<TextFieldProps> = React.forwardRef(
           maxRows={maxRows}
           inputProps={{
             pattern,
+            ...inputProps,
           }}
           startAdornment={
             icon ? (
@@ -185,3 +193,4 @@ export const TextField: FC<TextFieldProps> = React.forwardRef(
     );
   }
 );
+TextField.displayName = 'TextField';

--- a/src/components/inputs/textField/textField.stories.tsx
+++ b/src/components/inputs/textField/textField.stories.tsx
@@ -48,6 +48,16 @@ export const TextFields: ComponentStory<typeof TextField> = () => {
         multiline
         rows={3}
       />
+      <TextField
+        id="numeric-input"
+        placeholder="Numeric input"
+        label="Numeric input"
+        inputProps={{
+          type: 'number',
+          min: 0,
+          max: 10,
+        }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
closes https://github.com/squaredev-io/matte/issues/112

example:
```js
      <TextField
        id="numeric-input"
        placeholder="Numeric input"
        label="Numeric input"
        inputProps={{
          type: 'number',
          min: 0,
          max: 10,
        }}
      />
```