### PR TITLE
fix: dont minify outputted files

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,7 +1,6 @@
 import postcss from 'rollup-plugin-postcss';
 import typescript from 'rollup-plugin-typescript2';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import { terser } from 'rollup-plugin-terser';
 
 export default {
   input: 'src/index.tsx',
@@ -14,7 +13,6 @@ export default {
       preserveModules: true,
       preserveModulesRoot: 'src',
       sourcemap: true,
-      plugins: [terser()],
       exports: 'named',
     },
     {
@@ -25,7 +23,6 @@ export default {
       preserveModulesRoot: 'src',
       sourcemap: true,
       exports: 'named',
-      plugins: [terser()],
     },
   ],
   plugins: [


### PR DESCRIPTION
minification is lossy. So applying minification twice, once by matte-ui and once by the consumer, can result in bugs