### PR TITLE
Fix: Adds flex 1 to datepicker and select component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matte-ui",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Matte is a UI component library on top of MUI and other react libraries.",
   "author": "Squaredev",
   "license": "Apache-2.0",

--- a/src/components/inputs/datePicker/datePicker.module.scss
+++ b/src/components/inputs/datePicker/datePicker.module.scss
@@ -24,6 +24,7 @@
 .textFieldLeft {
   margin-bottom: 0px;
   margin-left: 16px;
+  flex: 1;
 }
 
 :global {

--- a/src/components/inputs/select/select.module.scss
+++ b/src/components/inputs/select/select.module.scss
@@ -65,4 +65,5 @@
 
 .leftInputBase {
   margin-left: 16px;
+  flex: 1;
 }


### PR DESCRIPTION
Applied flex: 1 to the Datepicker and Select component so that all the components that have the leftLabel props have the same width. Just for demonstration purposes this is what a Datepicker and Textfield looked like before the fix (different widths) and after fix. 
![Screenshot 2022-07-26 at 12 12 36 PM](https://user-images.githubusercontent.com/68306689/180970614-97914a7f-02a4-45ff-a0d7-df29715f67f6.png)
![Screenshot 2022-07-26 at 12 12 52 PM](https://user-images.githubusercontent.com/68306689/180970633-69944a90-3888-4938-af78-333dfb911346.png)

